### PR TITLE
Bump node 16 -> 20 because new github action rules

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
     required: false
     description: 'Override existing environment variables'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: command


### PR DESCRIPTION
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/